### PR TITLE
Add CMake build and GoogleTest suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Build directories
 build/
 CMakeFiles/
@@ -11,3 +12,6 @@ obj/
 # Object files
 *.o
 *.d
+=======
+build/
+>>>>>>> 40b27e1 (Add CMake build with GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,21 @@
-cmake_minimum_required(VERSION 3.5)
-project(EEDatabase C)
+cmake_minimum_required(VERSION 3.14)
+project(EEDatabase C CXX)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_STANDARD_REQUIRED ON)
 
-# Output binaries to bin/ similar to the old Makefile
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+# Library
+file(GLOB SRC_FILES src/*.c)
+add_library(EEDatabase ${SRC_FILES})
+target_include_directories(EEDatabase PUBLIC ${PROJECT_SOURCE_DIR}/inc)
+target_compile_options(EEDatabase PUBLIC -Wall -O3 -g)
 
-add_executable(EEDatabase
-    src/EEPROM_Mapping.c
-    src/database.c
-    src/factory_defaults.c
-    src/test.c
+# GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
 )
+FetchContent_MakeAvailable(googletest)
 
-target_include_directories(EEDatabase PRIVATE ${CMAKE_SOURCE_DIR}/inc)
-
-target_compile_options(EEDatabase PRIVATE -Wall -O3 -g -Wno-pointer-to-int-cast)
+enable_testing()
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ cmake --build build
 
 This repository is a starting point for managing small databases in embedded applications. Use the code as a reference for structuring and manipulating EEPROM-based data.
 
+
+## Building and Testing with CMake
+
+A CMake build is provided for running the unit tests. Create a build directory, configure the project and invoke `ctest`:
+
+```bash
+cmake -S . -B build
+cmake --build build
+cd build
+ctest
+```
+
+This will download GoogleTest, build the `EEDatabase` library and run the automated test suite.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(ee_database_tests test_database.cpp)
+target_link_libraries(ee_database_tests PRIVATE EEDatabase gtest_main)
+target_include_directories(ee_database_tests PRIVATE ${PROJECT_SOURCE_DIR}/inc)
+target_compile_options(ee_database_tests PRIVATE -Wno-pointer-to-int-cast -fpermissive)
+add_test(NAME ee_database_tests COMMAND ee_database_tests)

--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+extern "C" {
+#include "database.h"
+#include "EEPROM_Mapping.h"
+}
+
+TEST(EEReadWrite, WriteAndReadBack) {
+    const UINT16_t addr = 0;
+    UINT8_t write_buf[16];
+    UINT8_t read_buf[16];
+
+    for (UINT8_t i = 0; i < 16; ++i) {
+        write_buf[i] = i;
+        read_buf[i] = 0;
+    }
+
+    EXPECT_EQ(EE_ReadWrite(addr, write_buf, sizeof(write_buf), EEOP_WRITE), EE_OK);
+    EXPECT_EQ(EE_ReadWrite(addr, read_buf, sizeof(read_buf), EEOP_READ), EE_OK);
+
+    for (int i = 0; i < 16; ++i) {
+        EXPECT_EQ(write_buf[i], read_buf[i]);
+    }
+}
+
+TEST(Database, InitializeSetsSignature) {
+    UINT32_t signature = 0;
+    EXPECT_EQ(DB_Initialize(), EE_OK);
+    UINT16_t addr = EE_DB_SIGNATURE_OFFSET();
+    EXPECT_EQ(EE_ReadWrite(addr, (UINT8_t*)&signature, sizeof(signature), EEOP_READ), EE_OK);
+    EXPECT_EQ(signature, EE_DATABASE_SIGNATURE);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- provide root CMake build that builds the library and downloads GoogleTest
- add unit tests verifying `EE_ReadWrite` and `DB_Initialize`
- document how to run tests with CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68436c461b788329a80d5290db48fec9