### PR TITLE
Fix zero-fill bounds and adjust tests

### DIFF
--- a/src/EEDatabase.cpp
+++ b/src/EEDatabase.cpp
@@ -28,7 +28,7 @@ UINT8_t EEPROM::EE_MEMORY[EE_PAGESIZE * EE_PAGES] = {0};
 EE_ReturnCode_t EEPROM::ReadPage(UINT16_t Address, UINT8_t *pReadBuffer,
                                  size_t Size) {
     EE_ReturnCode_t result = EE_INVALIDADDRESS;
-    if (Address <= (EE_DATABASE_SIZE - EE_PAGESIZE)) {
+    if ((Address + Size) <= EE_DATABASE_SIZE) {
 #ifdef __SIMULATE_EE_MEMORY_AS_ARRAY
         memcpy(pReadBuffer, &EE_MEMORY[Address], Size);
 #endif
@@ -40,7 +40,7 @@ EE_ReturnCode_t EEPROM::ReadPage(UINT16_t Address, UINT8_t *pReadBuffer,
 EE_ReturnCode_t EEPROM::WritePage(UINT16_t Address, UINT8_t *pWriteBuffer,
                                   size_t Size) {
     EE_ReturnCode_t result = EE_INVALIDADDRESS;
-    if (Address <= (EE_DATABASE_SIZE - EE_PAGESIZE)) {
+    if ((Address + Size) <= EE_DATABASE_SIZE) {
 #ifdef __SIMULATE_EE_MEMORY_AS_ARRAY
         memcpy(&EE_MEMORY[Address], pWriteBuffer, Size);
 #endif
@@ -232,7 +232,11 @@ EE_ReturnCode_t EEDatabase::DB_ZeroFillEE() {
     int address;
     memset(gReadWriteBuffer, 0, sizeof(gReadWriteBuffer));
     for (address = 0; address < EE_DATABASE_SIZE; address += EE_PAGESIZE) {
-        if ((result = EEPROM::ReadWrite(address, gReadWriteBuffer, EE_PAGESIZE, EEOP_WRITE)) != EE_OK) {
+        size_t chunk = EE_PAGESIZE;
+        if ((address + chunk) > EE_DATABASE_SIZE) {
+            chunk = EE_DATABASE_SIZE - address;
+        }
+        if ((result = EEPROM::ReadWrite(address, gReadWriteBuffer, chunk, EEOP_WRITE)) != EE_OK) {
             break;
         }
     }

--- a/src/EEPROM_Mapping.c
+++ b/src/EEPROM_Mapping.c
@@ -119,7 +119,7 @@ _STATIC EE_ReturnCode_t EE_ReadPage(UINT16_t Address, UINT8_t * pReadBuffer,
                 size_t Size)
 {
         EE_ReturnCode_t result = EE_INVALIDADDRESS;
-       if ( Address <= (EE_DATABASE_SIZE - EE_PAGESIZE) )
+       if ( (Address + Size) <= EE_DATABASE_SIZE )
         {
 #ifdef __SIMULATE_EE_MEMORY_AS_ARRAY
                 memcpy((void*)pReadBuffer, (void*)&EE_MEMORY[Address], Size);
@@ -151,7 +151,7 @@ _STATIC EE_ReturnCode_t EE_WritePage(UINT16_t Address, UINT8_t * pWriteBuffer,
                                              size_t Size)
 {
         EE_ReturnCode_t result = EE_INVALIDADDRESS;
-       if ( Address <= (EE_DATABASE_SIZE - EE_PAGESIZE) )
+       if ( (Address + Size) <= EE_DATABASE_SIZE )
         {
 #ifdef __SIMULATE_EE_MEMORY_AS_ARRAY
                 memcpy((void*)&EE_MEMORY[Address], (void*)pWriteBuffer, Size);

--- a/src/database.c
+++ b/src/database.c
@@ -146,13 +146,18 @@ EE_ReturnCode_t DB_ZeroFillEE(_VOID)
 	/* Clear the buffer to 0s */
 	memset(gReadWriteBuffer, 0, sizeof(gReadWriteBuffer));
 
-	/* for each page, fill with 0s */
-	for(address=0; address<EE_DATABASE_SIZE; address+=EE_PAGESIZE)
-	{
-		if ( (result = EE_ReadWrite(address, gReadWriteBuffer, EE_PAGESIZE, EEOP_WRITE)) != EE_OK )
-		{
-			break;
-		}
+        /* for each page, fill with 0s */
+        for(address=0; address<EE_DATABASE_SIZE; address+=EE_PAGESIZE)
+        {
+                size_t chunk = EE_PAGESIZE;
+                if ((address + chunk) > EE_DATABASE_SIZE)
+                {
+                        chunk = EE_DATABASE_SIZE - address;
+                }
+                if ( (result = EE_ReadWrite(address, gReadWriteBuffer, chunk, EEOP_WRITE)) != EE_OK )
+                {
+                        break;
+                }
 
 		/* kick the watch dog if its enabled so that
 		 * cpu reset doesn't happen during zero fill */

--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -54,8 +54,8 @@ TEST(EEReadWrite, CrossPageWriteRead) {
     }
 }
 
-TEST(Database, ZeroFillFails) {
-    EXPECT_EQ(EEDatabase::DB_ZeroFillEE(), EE_INVALIDADDRESS);
+TEST(Database, ZeroFillSucceeds) {
+    EXPECT_EQ(EEDatabase::DB_ZeroFillEE(), EE_OK);
 }
 
 TEST(Database, DatabaseSignatureNull) {
@@ -174,9 +174,9 @@ TEST(Database, SensorInfoWriteReadHighIndex) {
     sensor_write.detected = B_TRUE;
     sensor_write.data.datetimestamp = 4321;
     sensor_write.data.value = 11.22f;
-    EXPECT_EQ(EEDatabase::DB_ReadWriteSensorInfo(NUM_SENSORS - 1, &sensor_write, EEOP_WRITE), EE_INVALIDADDRESS);
+    EXPECT_EQ(EEDatabase::DB_ReadWriteSensorInfo(NUM_SENSORS - 1, &sensor_write, EEOP_WRITE), EE_OK);
     EESensorData_t sensor_read{};
-    EXPECT_EQ(EEDatabase::DB_ReadWriteSensorInfo(NUM_SENSORS - 1, &sensor_read, EEOP_READ), EE_INVALIDADDRESS);
+    EXPECT_EQ(EEDatabase::DB_ReadWriteSensorInfo(NUM_SENSORS - 1, &sensor_read, EEOP_READ), EE_OK);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- update EEPROM read/write page checks
- handle partial page in `DB_ZeroFillEE`
- fix zero fill and sensor high index tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68438ba4c3b0832980f7ba6b0c31f701